### PR TITLE
Add tutorial page for listing instructions/helpful links

### DIFF
--- a/troposphere/static/js/AppRoutes.jsx
+++ b/troposphere/static/js/AppRoutes.jsx
@@ -60,6 +60,7 @@ import BMIPage from "./components/bmi/BMIPage";
 import HILPage from "./components/hil/HILPage";
 import NetexPage from "./components/netex/NetexPage";
 import MixmatchPage from "./components/mixmatch/MixmatchPage";
+import TutorialPage from "./components/tutorial/TutorialPage";
 
 const providersRoute = (
 <Route path="providers" component={ProvidersMaster}>
@@ -124,6 +125,7 @@ function AppRoutes(props) {
             <Route path="hil" component={HILPage} />
             <Route path="netex" component={NetexPage} />
             <Route path="mixmatch" component={MixmatchPage} />
+            <Route path="tutorials" component={TutorialPage} />
             <Route path="settings" component={SettingsPage} />
             <Route
                 path="admin"

--- a/troposphere/static/js/components/MOCHeader.jsx
+++ b/troposphere/static/js/components/MOCHeader.jsx
@@ -30,6 +30,13 @@ const links = [
         requiresLogin: true
     },
     {
+        name: "Tutorials",
+        linksTo: "tutorials",
+        href: "/application/tutorials",
+        icon: "file",
+        requiresLogin: true
+    },
+    {
         name: "Settings",
         linksTo: "settings",
         href: "/application/settings",

--- a/troposphere/static/js/components/tutorial/TutorialPage.jsx
+++ b/troposphere/static/js/components/tutorial/TutorialPage.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+
+export default React.createClass({
+    displayName: "TutorialPage",
+
+    render: function() {
+
+    return (
+        <div style={{paddingTop: "50px"}} className="container">
+            <h1 className="t-display-1">MOC GIJI Tutorials</h1>
+            <div>
+                <p>
+                    Please view this for instructions of launching instances
+                </p>
+            </div>
+        </div>
+        );
+    }
+});

--- a/troposphere/static/js/components/tutorial/TutorialPage.jsx
+++ b/troposphere/static/js/components/tutorial/TutorialPage.jsx
@@ -8,12 +8,19 @@ export default React.createClass({
 
     return (
         <div style={{paddingTop: "50px"}} className="container">
-            <h1 className="t-display-1">MOC GIJI Tutorials</h1>
+            <h1 className="t-display-1">Tutorials</h1>
             <div>
+                <h3>How to launch an instance</h3>
                 <p>
-                    Please view this for instructions of launching instances
+                    Video is comming soon
                 </p>
             </div>
+            <div>
+                <h3>How to manage your SSH public key</h3>
+                <p>
+                    Video is comming soon
+                </p>
+            </div> 
         </div>
         );
     }

--- a/troposphere/static/js/components/tutorial/TutorialPage.jsx
+++ b/troposphere/static/js/components/tutorial/TutorialPage.jsx
@@ -10,13 +10,11 @@ export default React.createClass({
         <div style={{paddingTop: "50px"}} className="container">
             <h1 className="t-display-1">Tutorials</h1>
             <div>
-                <h3>How to launch an instance</h3>
+                <h4>How to launch an instance</h4>
                 <p>
                     Video is comming soon
                 </p>
-            </div>
-            <div>
-                <h3>How to manage your SSH public key</h3>
+                <h4>How to manage your SSH public key</h4>
                 <p>
                     Video is comming soon
                 </p>


### PR DESCRIPTION
## Description

We need to have a page for showing our users how to do things such as launching instances, uploading keypairs and FAQs etc.

This patch adds the page and it is currently a WIP
